### PR TITLE
chore: migrate zipc for strict nightly CI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 target/
 .mooncakes/
 .DS_Store
+_build/

--- a/adler32/adler32_test.mbt
+++ b/adler32/adler32_test.mbt
@@ -85,15 +85,15 @@ test "adler32_binary_data" {
 test "bytes" {
   // Verified test against Python's zlib.adler32()
   inspect(
-    @adler32.bytes("hello world hgoho xx yy zz aa bb cc dd ee ff"),
+    @adler32.bytes(b"hello world hgoho xx yy zz aa bb cc dd ee ff"),
     content="0x545410050481025150",
   )
   inspect(
-    @adler32.bytes("hello world hgoho xx yy zz aa bb cc dd ee ff").0,
+    @adler32.bytes(b"hello world hgoho xx yy zz aa bb cc dd ee ff").0,
     content="1725042482",
   )
   inspect(
-    @adler32.bytes("hello world hgoho xx yy zz aa bb cc dd ee").0,
+    @adler32.bytes(b"hello world hgoho xx yy zz aa bb cc dd ee").0,
     content="980291142",
   )
 }

--- a/adler32/adler32_test.mbt
+++ b/adler32/adler32_test.mbt
@@ -11,7 +11,7 @@ test "adler32_empty_bytes" {
 
 ///|
 test "adler32_hello_world_bytes" {
-  let test_bytes = "Hello, World!".to_bytes()
+  let test_bytes = b"Hello, World!"
   let adler = @adler32.bytes(test_bytes)
   let empty_adler = @adler32.bytes(Bytes::from_array([]))
   // Test that we get some Adler value different from empty
@@ -21,10 +21,10 @@ test "adler32_hello_world_bytes" {
 ///|
 test "adler32_equality_modern" {
   let test_data = "test data"
-  let test_bytes = test_data.to_bytes()
+  let test_bytes = @utf8.encode(test_data)
   let adler1 = @adler32.bytes(test_bytes)
   let adler2 = @adler32.bytes(test_bytes)
-  let different_adler = @adler32.bytes("different".to_bytes())
+  let different_adler = @adler32.bytes(b"different")
 
   // Test struct equality (modern way)
   assert_eq(adler1 == adler2, true)
@@ -34,7 +34,7 @@ test "adler32_equality_modern" {
 
 ///|
 test "adler32_show_implementation" {
-  let test_bytes = "Hello, Adler32!".to_bytes()
+  let test_bytes = b"Hello, Adler32!"
   let adler = @adler32.bytes(test_bytes)
 
   // Test Show implementation works (should display hex format)
@@ -49,19 +49,19 @@ test "adler32_show_implementation" {
 ///|
 test "adler32_various_data_sizes" {
   // Test small data
-  let small = @adler32.bytes("a".to_bytes())
+  let small = @adler32.bytes(b"a")
   let empty = @adler32.bytes(Bytes::from_array([]))
   assert_true(small != empty)
 
   // Test medium data
   let medium = @adler32.bytes(
-    "Hello, this is a medium sized test string!".to_bytes(),
+    b"Hello, this is a medium sized test string!",
   )
   assert_true(medium != small)
   assert_true(medium != empty)
 
   // Test large data
-  let large_data = "This is a much larger test string that should produce a different Adler-32 checksum than the smaller ones. It contains multiple sentences and should thoroughly test the checksum algorithm.".to_bytes()
+  let large_data = b"This is a much larger test string that should produce a different Adler-32 checksum than the smaller ones. It contains multiple sentences and should thoroughly test the checksum algorithm."
   let large = @adler32.bytes(large_data)
   assert_true(large != medium)
   assert_true(large != small)

--- a/adler32/moon.pkg
+++ b/adler32/moon.pkg
@@ -1,0 +1,3 @@
+options(
+  test_import: [ "moonbitlang/core/encoding/utf8" ],
+)

--- a/adler32/pkg.generated.mbti
+++ b/adler32/pkg.generated.mbti
@@ -8,8 +8,6 @@ pub fn bytes(Bytes) -> Adler32
 
 // Types and methods
 pub(all) struct Adler32(Int64) derive(Eq)
-#deprecated
-pub fn Adler32::inner(Self) -> Int64
 pub impl Show for Adler32
 
 // Type aliases

--- a/adler32/pkg.generated.mbti
+++ b/adler32/pkg.generated.mbti
@@ -2,15 +2,15 @@
 package "bobzhang/zipc/adler32"
 
 // Values
-fn bytes(Bytes) -> Adler32
+pub fn bytes(Bytes) -> Adler32
 
 // Errors
 
 // Types and methods
-pub(all) struct Adler32(Int64)
-fn Adler32::inner(Self) -> Int64
-impl Eq for Adler32
-impl Show for Adler32
+pub(all) struct Adler32(Int64) derive(Eq)
+#deprecated
+pub fn Adler32::inner(Self) -> Int64
+pub impl Show for Adler32
 
 // Type aliases
 

--- a/crc32/crc32.mbt
+++ b/crc32/crc32.mbt
@@ -96,7 +96,7 @@ pub impl Show for Crc32 with output(crc, logger) {
   let mut value = crc.0
   for i = 0; i < 8; i = i + 1 {
     let digit = value.land(0xfL).to_int()
-    result = hex_chars[digit].to_string() + result
+    result = hex_chars.code_unit_at(digit).to_int().unsafe_to_char().to_string() + result
     value = value >> 4
   }
   logger.write_string("0x" + result)

--- a/crc32/crc32_test.mbt
+++ b/crc32/crc32_test.mbt
@@ -9,16 +9,16 @@ test "crc32_empty_bytes" {
 
 ///|
 test "crc32_hello_world" {
-  let crc = @crc32.bytes("Hello, World!".to_bytes())
+  let crc = @crc32.bytes(b"Hello, World!")
   // Test that we get some CRC value (exact value may vary)
   assert_true(crc != Crc32(0L))
 }
 
 ///|
 test "crc32_equality" {
-  let crc1 = @crc32.bytes("test".to_bytes())
-  let crc2 = @crc32.bytes("test".to_bytes())
-  let crc3 = @crc32.bytes("different".to_bytes())
+  let crc1 = @crc32.bytes(b"test")
+  let crc2 = @crc32.bytes(b"test")
+  let crc3 = @crc32.bytes(b"different")
   assert_eq(crc1, crc2)
   assert_not_eq(crc1, crc3)
 }
@@ -26,9 +26,9 @@ test "crc32_equality" {
 ///|
 test "crc32_bytes_consistency" {
   let test_string = "Hello, Bytes!"
-  let test_bytes = test_string.to_bytes()
+  let test_bytes = @utf8.encode(test_string)
   let crc1 = @crc32.bytes(test_bytes)
-  let crc2 = @crc32.bytes(test_string.to_bytes())
+  let crc2 = @crc32.bytes(@utf8.encode(test_string))
 
   // Both should produce the same result
   assert_eq(crc1, crc2)
@@ -39,49 +39,73 @@ test "crc32_bytes_consistency" {
 test "crc32_bytes" {
   // Below tests are verified, it should not be changed.
   // MOONBIT supports overloading, in check modes, "" will be interpreted as Bytes
-  inspect(@crc32.bytes("hello".to_bytes()), content="0x535349505550100102")
+  inspect(@crc32.bytes(b"hello"), content=(
+    #|0x3610a686
+  ))
   inspect(
-    @crc32.bytes("hello world hgoho".to_bytes()),
-    content="0x4898102545751100102",
+    @crc32.bytes(b"hello world hgoho"),
+    content=(
+      #|0x65f3568b
+    ),
   )
   inspect(
-    @crc32.bytes("hello world hgoho xx".to_bytes()),
-    content="0x5053575356979856",
+    @crc32.bytes(b"hello world hgoho xx"),
+    content=(
+      #|0x5b013872
+    ),
   )
   inspect(
-    @crc32.bytes("hello world hgoho xx yy".to_bytes()),
-    content="0x10155555150535697",
+    @crc32.bytes(b"hello world hgoho xx yy"),
+    content=(
+      #|0x27c5a4dd
+    ),
   )
   inspect(
-    @crc32.bytes("hello world hgoho xx yy zz".to_bytes()),
-    content="0x4852494950985699",
+    @crc32.bytes(b"hello world hgoho xx yy zz"),
+    content=(
+      #|0x06387f3a
+    ),
   )
   inspect(
-    @crc32.bytes("hello world hgoho xx yy zz aa".to_bytes()),
-    content="0x555710010051995653",
+    @crc32.bytes(b"hello world hgoho xx yy zz aa"),
+    content=(
+      #|0x2806293d
+    ),
   )
   inspect(
-    @crc32.bytes("hello world hgoho xx yy zz aa bb".to_bytes()),
-    content="0x100535156554852102",
+    @crc32.bytes(b"hello world hgoho xx yy zz aa bb"),
+    content=(
+      #|0xb2edda96
+    ),
   )
   inspect(
-    @crc32.bytes("hello world hgoho xx yy zz aa bb cc".to_bytes()),
-    content="0x545650999898102102",
+    @crc32.bytes(b"hello world hgoho xx yy zz aa bb cc"),
+    content=(
+      #|0x0195e0d4
+    ),
   )
   inspect(
-    @crc32.bytes("hello world hgoho xx yy zz aa bb cc dd".to_bytes()),
-    content="0x5099525655509853",
+    @crc32.bytes(b"hello world hgoho xx yy zz aa bb cc dd"),
+    content=(
+      #|0xd8d99dda
+    ),
   )
   inspect(
-    @crc32.bytes("hello world hgoho xx yy zz aa bb cc dd ee".to_bytes()),
-    content="0x485210210199505557",
+    @crc32.bytes(b"hello world hgoho xx yy zz aa bb cc dd ee"),
+    content=(
+      #|0x59a0bbde
+    ),
   )
   inspect(
-    @crc32.bytes("hello world hgoho xx yy zz aa bb cc dd ee ff".to_bytes()),
-    content="0x525399991011015749",
+    @crc32.bytes(b"hello world hgoho xx yy zz aa bb cc dd ee ff"),
+    content=(
+      #|0x068a5b46
+    ),
   )
   inspect(
-    @crc32.bytes("hello world hgoho xx yy zz aa bb cc dd ee ff".to_bytes()).0,
-    content="1171058321",
+    @crc32.bytes(b"hello world hgoho xx yy zz aa bb cc dd ee ff").0,
+    content=(
+      #|109730630
+    ),
   )
 }

--- a/crc32/moon.pkg
+++ b/crc32/moon.pkg
@@ -1,0 +1,3 @@
+options(
+  test_import: [ "moonbitlang/core/encoding/utf8" ],
+)

--- a/crc32/pkg.generated.mbti
+++ b/crc32/pkg.generated.mbti
@@ -2,15 +2,15 @@
 package "bobzhang/zipc/crc32"
 
 // Values
-fn bytes(Bytes) -> Crc32
+pub fn bytes(Bytes) -> Crc32
 
 // Errors
 
 // Types and methods
-pub(all) struct Crc32(Int64)
-fn Crc32::inner(Self) -> Int64
-impl Eq for Crc32
-impl Show for Crc32
+pub(all) struct Crc32(Int64) derive(Eq)
+#deprecated
+pub fn Crc32::inner(Self) -> Int64
+pub impl Show for Crc32
 
 // Type aliases
 

--- a/crc32/pkg.generated.mbti
+++ b/crc32/pkg.generated.mbti
@@ -8,8 +8,6 @@ pub fn bytes(Bytes) -> Crc32
 
 // Types and methods
 pub(all) struct Crc32(Int64) derive(Eq)
-#deprecated
-pub fn Crc32::inner(Self) -> Int64
 pub impl Show for Crc32
 
 // Type aliases

--- a/deflate/gzip.mbt
+++ b/deflate/gzip.mbt
@@ -84,14 +84,14 @@ pub fn gzip_compress_bytes(
       // Optional filename (null-terminated)
       match filename {
         Some(name) =>
-          header = header + name.to_bytes() + Bytes::from_array([0x00])
+          header = header + @utf8.encode(name) + Bytes::from_array([0x00])
         None => ()
       }
 
       // Optional comment (null-terminated)
       match comment {
         Some(comm) =>
-          header = header + comm.to_bytes() + Bytes::from_array([0x00])
+          header = header + @utf8.encode(comm) + Bytes::from_array([0x00])
         None => ()
       }
 

--- a/deflate/moon.pkg
+++ b/deflate/moon.pkg
@@ -2,6 +2,9 @@ import {
   "bobzhang/zipc/crc32",
   "bobzhang/zipc/adler32",
   "bobzhang/zipc/huffman",
+  "moonbitlang/core/buffer",
+  "moonbitlang/core/debug",
+  "moonbitlang/core/encoding/utf8",
 }
 
 options(

--- a/deflate/pkg.generated.mbti
+++ b/deflate/pkg.generated.mbti
@@ -1,55 +1,56 @@
 // Generated using `moon info`, DON'T EDIT IT
 package "bobzhang/zipc/deflate"
 
-import(
-  "bobzhang/zipc/adler32"
-  "bobzhang/zipc/crc32"
-)
+import {
+  "bobzhang/zipc/adler32",
+  "bobzhang/zipc/crc32",
+  "moonbitlang/core/debug",
+}
 
 // Values
-fn deflate_compress(Bytes, Level) -> DeflateData
+pub fn deflate_compress(Bytes, Level) -> DeflateData
 
-fn deflate_decompress(DeflateData) -> Bytes raise
+pub fn deflate_decompress(DeflateData) -> Bytes raise
 
-fn deflate_decompress_bytes(Bytes, Int) -> Bytes raise
+pub fn deflate_decompress_bytes(Bytes, Int) -> Bytes raise
 
-fn deflate_decompress_raw_bytes(Bytes, Int) -> Bytes raise
+pub fn deflate_decompress_raw_bytes(Bytes, Int) -> Bytes raise
 
-fn deflate_of_bytes(Bytes, Level) -> Bytes
+pub fn deflate_of_bytes(Bytes, Level) -> Bytes
 
-fn[T, E] err(E) -> Result[T, E]
+pub fn[T, E] err(E) -> Result[T, E]
 
-fn gzip_compress_bytes(Bytes, Level, String?, String?, Int) -> GzipData
+pub fn gzip_compress_bytes(Bytes, Level, String?, String?, Int) -> GzipData
 
-fn gzip_decompress_bytes(GzipData) -> Bytes raise
+pub fn gzip_decompress_bytes(GzipData) -> Bytes raise
 
-fn gzip_extract_metadata_bytes(Bytes) -> Result[GzipData, String]
+pub fn gzip_extract_metadata_bytes(Bytes) -> Result[GzipData, String]
 
-fn gzip_of_bytes(Bytes, Level, String?, String?) -> Bytes
+pub fn gzip_of_bytes(Bytes, Level, String?, String?) -> Bytes
 
-fn gzip_to_bytes(Bytes) -> Bytes raise
+pub fn gzip_to_bytes(Bytes) -> Bytes raise
 
-fn level_best() -> Level
+pub fn level_best() -> Level
 
-fn level_default() -> Level
+pub fn level_default() -> Level
 
-fn level_fast() -> Level
+pub fn level_fast() -> Level
 
-fn level_none() -> Level
+pub fn level_none() -> Level
 
-fn[T, E] ok(T) -> Result[T, E]
+pub fn[T, E] ok(T) -> Result[T, E]
 
-fn[T, E] unwrap(Result[T, E]) -> T
+pub fn[T, E] unwrap(Result[T, E]) -> T
 
-fn[T, E] unwrap_or(Result[T, E], T) -> T
+pub fn[T, E] unwrap_or(Result[T, E], T) -> T
 
-fn zlib_compress_bytes(Bytes, Level) -> ZlibData
+pub fn zlib_compress_bytes(Bytes, Level) -> ZlibData
 
-fn zlib_decompress_bytes(ZlibData) -> Bytes raise
+pub fn zlib_decompress_bytes(ZlibData) -> Bytes raise
 
-fn zlib_of_bytes(Bytes, Level) -> Bytes
+pub fn zlib_of_bytes(Bytes, Level) -> Bytes
 
-fn zlib_to_bytes(Bytes, Int) -> Bytes raise
+pub fn zlib_to_bytes(Bytes, Int) -> Bytes raise
 
 // Errors
 
@@ -74,8 +75,8 @@ pub enum Level {
   Fast
   Default
   Best
-}
-impl Show for Level
+} derive(@debug.Debug)
+pub impl Show for Level
 
 pub enum Result[T, E] {
   Ok(T)
@@ -89,7 +90,7 @@ pub struct ZlibData {
 }
 
 // Type aliases
-pub typealias Int64 as UInt32
+pub type UInt32 = Int64
 
 // Traits
 

--- a/deflate/types.mbt
+++ b/deflate/types.mbt
@@ -1,7 +1,7 @@
 // Core types for deflate module
 
 ///|
-pub typealias Int64 as UInt32
+pub type UInt32 = Int64
 
 // Compression levels
 
@@ -11,7 +11,7 @@ pub enum Level {
   Fast
   Default
   Best
-} derive(Show)
+} derive(Debug)
 
 // Helper functions to create Level values
 
@@ -75,4 +75,9 @@ pub fn[T, E] unwrap_or(result : Result[T, E], default : T) -> T {
     Ok(value) => value
     Err(_) => default
   }
+}
+
+///|
+pub impl Show for Level with output(self, logger) {
+  logger.write_string(@debug.render(self.to_repr(), max_depth=2147483647))
 }

--- a/extra_fields.mbt
+++ b/extra_fields.mbt
@@ -47,7 +47,7 @@ pub fn parse_extra_fields(data : String) -> Array[ExtraField] {
 
     // Read data
     if offset + data_size <= data.length() {
-      let field_data = data.substring(start=offset, end=offset + data_size)
+      let field_data = data[offset:offset + data_size].to_string()
       fields.push({ header_id, data_size, data: field_data })
       offset = offset + data_size
     } else {
@@ -193,7 +193,7 @@ pub fn parse_unicode_path_field(field : ExtraField) -> (String, Int)? {
     return None // Unsupported version
   }
   let crc32 = read_u32_le_extra(field.data, 1)
-  let unicode_path = field.data.substring(start=5, end=field.data.length())
+  let unicode_path = field.data[5:field.data.length()].to_string()
   Some((unicode_path, crc32))
 }
 

--- a/huffman/huffman.mbt
+++ b/huffman/huffman.mbt
@@ -6,7 +6,7 @@
 pub struct BitReader {
   data : Bytes
   mut bit_offset : Int // Current bit position
-} derive(Show)
+} derive(Debug)
 
 // Create a new bit reader
 
@@ -18,7 +18,7 @@ pub fn new_bit_reader(data : Bytes) -> BitReader {
 // Read bits from the stream (LSB first, as per RFC 1951)
 
 ///|
-pub fn read_bits(self : BitReader, num_bits : Int) -> Int {
+pub fn BitReader::read_bits(self : BitReader, num_bits : Int) -> Int {
   if num_bits <= 0 || num_bits > 32 {
     return 0
   }
@@ -44,7 +44,7 @@ pub fn read_bits(self : BitReader, num_bits : Int) -> Int {
 // Check if we're at the end of data
 
 ///|
-pub fn is_at_end(self : BitReader) -> Bool {
+pub fn BitReader::is_at_end(self : BitReader) -> Bool {
   self.bit_offset >= self.data.length() * 8
 }
 
@@ -360,7 +360,7 @@ pub fn decompress_fixed_huffman_block_bytes(
   let output = @buffer.new()
   let mut symbols_decoded = 0
   let max_symbols = 1000 // Prevent infinite loops
-  while not(reader.is_at_end()) && symbols_decoded < max_symbols {
+  while !reader.is_at_end() && symbols_decoded < max_symbols {
     // Decode literal/length symbol
     let symbol = match decode_symbol(reader, literal_tree) {
       Some(s) => s
@@ -436,4 +436,9 @@ pub fn decompress_fixed_huffman_block_bytes(
   let bits_consumed = reader.bit_offset
   let bytes_consumed = (bits_consumed + 7) / 8 // Round up to next byte
   (output.to_bytes(), offset + bytes_consumed)
+}
+
+///|
+pub impl Show for BitReader with output(self, logger) {
+  logger.write_string(@debug.render(self.to_repr(), max_depth=2147483647))
 }

--- a/huffman/huffman_test.mbt
+++ b/huffman/huffman_test.mbt
@@ -86,7 +86,7 @@ test "huffman_tree_construction" {
 
 ///|
 test "symbol_decoding_basic" {
-  let data = "Hello World!".to_bytes()
+  let data = b"Hello World!"
   let reader = @huffman.new_bit_reader(data)
   let tree = @huffman.create_fixed_huffman_tree()
 
@@ -102,7 +102,7 @@ test "symbol_decoding_basic" {
 
 ///|
 test "length_distance_decoding" {
-  let data = "test".to_bytes()
+  let data = b"test"
   let reader = @huffman.new_bit_reader(data)
 
   // Test length codes
@@ -310,7 +310,7 @@ test "huffman_performance_large_data" {
 
   // Test reading many bits efficiently
   let mut total_bits_read = 0
-  while not(reader.is_at_end()) && total_bits_read < 8000 {
+  while !reader.is_at_end() && total_bits_read < 8000 {
     let _bits = reader.read_bits(8) // Read byte by byte
     total_bits_read += 8
   }
@@ -328,7 +328,7 @@ test "huffman_stress_test_repeated_patterns" {
   // Test with repeated patterns
   let pattern_data = @buffer.new()
   for i = 0; i < 100; i = i + 1 {
-    pattern_data.write_bytes("ABCDEFGH".to_bytes())
+    pattern_data.write_bytes(b"ABCDEFGH")
   }
   let compressed = pattern_data.to_bytes()
   match
@@ -359,7 +359,7 @@ test "huffman_boundary_conditions" {
   match
     {
       let (_decompressed, bytes_consumed) = @huffman.decompress_fixed_huffman_block_bytes(
-        "A".to_bytes(),
+        b"A",
         0,
       )
       inspect(bytes_consumed == 1, content="true")
@@ -373,7 +373,7 @@ test "huffman_boundary_conditions" {
   }
 
   // Test maximum valid offset
-  let data = "Hello World!".to_bytes()
+  let data = b"Hello World!"
   match
     {
       let (_, _) = @huffman.decompress_fixed_huffman_block_bytes(

--- a/huffman/moon.pkg
+++ b/huffman/moon.pkg
@@ -1,7 +1,9 @@
 import {
+  "moonbitlang/core/buffer",
+  "moonbitlang/core/debug",
 }
 
 options(
   is_main: false,
-  test_import: [ ],
+  test_import: [],
 )

--- a/huffman/pkg.generated.mbti
+++ b/huffman/pkg.generated.mbti
@@ -1,34 +1,38 @@
 // Generated using `moon info`, DON'T EDIT IT
 package "bobzhang/zipc/huffman"
 
+import {
+  "moonbitlang/core/debug",
+}
+
 // Values
-fn block_type_to_btype(BlockType) -> Int
+pub fn block_type_to_btype(BlockType) -> Int
 
-fn btype_to_block_type(Int) -> BlockType?
+pub fn btype_to_block_type(Int) -> BlockType?
 
-fn build_fixed_distance_tree() -> HuffmanNode?
+pub fn build_fixed_distance_tree() -> HuffmanNode?
 
-fn build_fixed_literal_tree() -> HuffmanNode?
+pub fn build_fixed_literal_tree() -> HuffmanNode?
 
-fn create_fixed_distance_tree() -> HuffmanNode
+pub fn create_fixed_distance_tree() -> HuffmanNode
 
-fn create_fixed_huffman_tree() -> HuffmanNode
+pub fn create_fixed_huffman_tree() -> HuffmanNode
 
-fn decode_symbol(BitReader, HuffmanNode) -> Int?
+pub fn decode_symbol(BitReader, HuffmanNode) -> Int?
 
-fn decompress_fixed_huffman_block_bytes(Bytes, Int) -> (Bytes, Int) raise
+pub fn decompress_fixed_huffman_block_bytes(Bytes, Int) -> (Bytes, Int) raise
 
-fn dynamic_huffman_block_type() -> BlockType
+pub fn dynamic_huffman_block_type() -> BlockType
 
-fn fixed_huffman_block_type() -> BlockType
+pub fn fixed_huffman_block_type() -> BlockType
 
-fn get_distance_from_code(BitReader, Int) -> Int?
+pub fn get_distance_from_code(BitReader, Int) -> Int?
 
-fn get_length_from_code(BitReader, Int) -> Int?
+pub fn get_length_from_code(BitReader, Int) -> Int?
 
-fn new_bit_reader(Bytes) -> BitReader
+pub fn new_bit_reader(Bytes) -> BitReader
 
-fn uncompressed_block_type() -> BlockType
+pub fn uncompressed_block_type() -> BlockType
 
 // Errors
 
@@ -36,25 +40,23 @@ fn uncompressed_block_type() -> BlockType
 pub struct BitReader {
   data : Bytes
   mut bit_offset : Int
-}
-fn BitReader::is_at_end(Self) -> Bool
-fn BitReader::read_bits(Self, Int) -> Int
-impl Show for BitReader
+} derive(@debug.Debug)
+pub fn BitReader::is_at_end(Self) -> Bool
+pub fn BitReader::read_bits(Self, Int) -> Int
+pub impl Show for BitReader
 
 pub enum BlockType {
   Uncompressed
   FixedHuffman
   DynamicHuffman
-}
-impl Eq for BlockType
-impl Show for BlockType
+} derive(Eq, @debug.Debug)
+pub impl Show for BlockType
 
 pub enum HuffmanNode {
   Leaf(Int)
   Branch(HuffmanNode, HuffmanNode)
-}
-impl Eq for HuffmanNode
-impl Show for HuffmanNode
+} derive(Eq, @debug.Debug)
+pub impl Show for HuffmanNode
 
 // Type aliases
 

--- a/huffman/types.mbt
+++ b/huffman/types.mbt
@@ -6,7 +6,7 @@
 pub enum HuffmanNode {
   Leaf(Int) // Symbol value (0-285 for literals/lengths, 0-29 for distances)
   Branch(HuffmanNode, HuffmanNode) // Left and right children
-} derive(Show, Eq)
+} derive(Debug, Eq)
 
 // Symbol with code information for tree building
 
@@ -24,7 +24,7 @@ pub enum BlockType {
   Uncompressed // No compression (BTYPE = 00)
   FixedHuffman // Compressed with fixed Huffman codes (BTYPE = 01)  
   DynamicHuffman // Compressed with dynamic Huffman codes (BTYPE = 10)
-} derive(Show, Eq)
+} derive(Debug, Eq)
 
 // Convert block type to BTYPE value
 
@@ -106,3 +106,13 @@ let distance_extra_bits : Array[Int] = [
 // let code_length_order : Array[Int] = [
 //   16, 17, 18, 0, 8, 7, 9, 6, 10, 5, 11, 4, 12, 3, 13, 2, 14, 1, 15
 // ]
+
+///|
+pub impl Show for HuffmanNode with output(self, logger) {
+  logger.write_string(@debug.render(self.to_repr(), max_depth=2147483647))
+}
+
+///|
+pub impl Show for BlockType with output(self, logger) {
+  logger.write_string(@debug.render(self.to_repr(), max_depth=2147483647))
+}

--- a/lz77/encoder.mbt
+++ b/lz77/encoder.mbt
@@ -383,8 +383,8 @@ pub fn encode_to_bytes(data : Bytes, config : LZ77Config) -> Bytes { // First, e
       LZ77Token::Reference(length, distance) => {
         // Reference format: marker (0x01) + varint(length) + varint(distance)
         output.write_byte(b'\x01')
-        output.write_leb128(length)
-        output.write_leb128(distance)
+        output.write_uleb128(length)
+        output.write_uleb128(distance)
       }
     }
   }
@@ -418,7 +418,7 @@ pub fn encode_to_bytes(data : Bytes, config : LZ77Config) -> Bytes { // First, e
 /// - 2 bytes for values 128-16383
 /// - 3 bytes for values 16384-2097151
 /// - etc.
-fn @buffer.T::write_leb128(buffer : Self, value : Int) -> Unit {
+fn @buffer.Buffer::write_uleb128(buffer : Self, value : Int) -> Unit {
   //TODO(upstream): upstream and change T to Buffer  
   if value < 128 {
     // Single byte: no continuation bit (0xxxxxxx)
@@ -426,31 +426,31 @@ fn @buffer.T::write_leb128(buffer : Self, value : Int) -> Unit {
   } else {
     // Multiple bytes: set continuation bit (1xxxxxxx) and recurse
     buffer.write_byte((value % 128 + 128).to_byte())
-    buffer.write_leb128(value / 128)
+    buffer.write_uleb128(value / 128)
   }
 }
 
 ///|
-test "write_leb128" {
+test "write_uleb128" {
   let buffer = @buffer.new()
-  buffer.write_leb128(0)
+  buffer.write_uleb128(0)
   assert_eq(buffer.to_bytes(), b"\x00")
   buffer.reset()
-  buffer.write_leb128(127)
+  buffer.write_uleb128(127)
   assert_eq(buffer.to_bytes(), b"\x7f")
   buffer.reset()
-  buffer.write_leb128(128)
+  buffer.write_uleb128(128)
   assert_eq(buffer.to_bytes(), b"\x80\x01")
   buffer.reset()
-  buffer.write_leb128(129)
+  buffer.write_uleb128(129)
   assert_eq(buffer.to_bytes(), b"\x81\x01")
   buffer.reset()
-  buffer.write_leb128(16383)
+  buffer.write_uleb128(16383)
   assert_eq(buffer.to_bytes(), b"\xff\x7f")
   buffer.reset()
-  buffer.write_leb128(16384)
+  buffer.write_uleb128(16384)
   assert_eq(buffer.to_bytes(), b"\x80\x80\x01")
   buffer.reset()
-  buffer.write_leb128(2097151)
+  buffer.write_uleb128(2097151)
   assert_eq(buffer.to_bytes(), b"\xff\xff\x7f")
 }

--- a/lz77/lz77_test.mbt
+++ b/lz77/lz77_test.mbt
@@ -31,7 +31,7 @@ test "lz77_simple_repetition" {
   let tokens = @lz77.encode_default(input)
   let decoded = @lz77.decode(tokens)
   assert_eq(decoded, input)
-  @json.inspect(tokens, content=[["Literal", 65], ["Reference", 3, 1]])
+  json_inspect(tokens, content=[["Literal", 65], ["Reference", 3, 1]])
 }
 
 // Test longer pattern matching
@@ -46,7 +46,7 @@ test "lz77_pattern_matching" {
   let tokens = @lz77.encode_default(input)
   let decoded = @lz77.decode(tokens)
   assert_eq(decoded, input)
-  @json.inspect(tokens, content=[
+  json_inspect(tokens, content=[
     ["Literal", 97],
     ["Literal", 98],
     ["Literal", 99],

--- a/lz77/moon.pkg
+++ b/lz77/moon.pkg
@@ -1,6 +1,11 @@
 import {
+  "moonbitlang/core/buffer",
+  "moonbitlang/core/debug",
 }
 
 options(
   "is-main": false,
+  test_import: [
+    "moonbitlang/core/encoding/utf8",
+  ],
 )

--- a/lz77/pkg.generated.mbti
+++ b/lz77/pkg.generated.mbti
@@ -1,54 +1,55 @@
 // Generated using `moon info`, DON'T EDIT IT
 package "bobzhang/zipc/lz77"
 
+import {
+  "moonbitlang/core/debug",
+}
+
 // Values
-fn decode(Array[LZ77Token]) -> Bytes raise
+pub fn decode(Array[LZ77Token]) -> Bytes raise
 
-fn decode_from_bytes(Bytes) -> Bytes raise
+pub fn decode_from_bytes(Bytes) -> Bytes raise
 
-fn default_config() -> LZ77Config
+pub fn default_config() -> LZ77Config
 
-fn encode(Bytes, LZ77Config) -> Array[LZ77Token]
+pub fn encode(Bytes, LZ77Config) -> Array[LZ77Token]
 
-fn encode_default(Bytes) -> Array[LZ77Token]
+pub fn encode_default(Bytes) -> Array[LZ77Token]
 
-fn encode_to_bytes(Bytes, LZ77Config) -> Bytes
+pub fn encode_to_bytes(Bytes, LZ77Config) -> Bytes
 
-fn get_compression_stats(Int, Array[LZ77Token]) -> (Int, Int, Double)
+pub fn get_compression_stats(Int, Array[LZ77Token]) -> (Int, Int, Double)
 
-fn hash3(Byte, Byte, Byte) -> Int
+pub fn hash3(Byte, Byte, Byte) -> Int
 
-fn new_decoder_state() -> DecoderState
+pub fn new_decoder_state() -> DecoderState
 
-fn new_encoder_state(LZ77Config) -> EncoderState
+pub fn new_encoder_state(LZ77Config) -> EncoderState
 
-fn validate_tokens(Array[LZ77Token]) -> Bool
+pub fn validate_tokens(Array[LZ77Token]) -> Bool
 
 // Errors
 
 // Types and methods
-type DecoderState
-impl Show for DecoderState
+type DecoderState derive(@debug.Debug)
+pub impl Show for DecoderState
 
-type EncoderState
-impl Show for EncoderState
+type EncoderState derive(@debug.Debug)
+pub impl Show for EncoderState
 
-pub struct LZ77Config {
+pub(all) struct LZ77Config {
   window_size : Int
   max_match_length : Int
   min_match_length : Int
   max_distance : Int
-}
-impl Eq for LZ77Config
-impl Show for LZ77Config
+} derive(Eq, @debug.Debug)
+pub impl Show for LZ77Config
 
 pub enum LZ77Token {
   Literal(Byte)
   Reference(Int, Int)
-}
-impl Eq for LZ77Token
-impl Show for LZ77Token
-impl ToJson for LZ77Token
+} derive(Eq, ToJson, @debug.Debug)
+pub impl Show for LZ77Token
 
 // Type aliases
 

--- a/lz77/types.mbt
+++ b/lz77/types.mbt
@@ -7,7 +7,7 @@
 pub enum LZ77Token {
   Literal(Byte) // Single literal byte
   Reference(Int, Int) // (length, distance) back-reference
-} derive(Show, Eq, ToJson)
+} derive(Debug, Eq, ToJson)
 
 // LZ77 compression parameters
 
@@ -17,7 +17,7 @@ pub(all) struct LZ77Config {
   max_match_length : Int // Maximum match length (typically 258 for DEFLATE)
   min_match_length : Int // Minimum match length (typically 3 for DEFLATE)
   max_distance : Int // Maximum back-reference distance
-} derive(Show, Eq)
+} derive(Debug, Eq)
 
 // Default LZ77 configuration compatible with DEFLATE
 
@@ -40,15 +40,15 @@ struct EncoderState {
   hash_table : Array[Int] // Hash table for fast string matching
   hash_head : Array[Int] // Hash chain heads
   hash_prev : Array[Int] // Hash chain previous pointers
-} derive(Show)
+} derive(Debug)
 
 // LZ77 decoder state
 
 ///|
 struct DecoderState {
   mut position : Int // Current position in output
-  output_buffer : @buffer.T // Output buffer for decoded data
-} derive(Show)
+  output_buffer : @buffer.Buffer // Output buffer for decoded data
+} derive(Debug)
 
 // Hash table size (power of 2 for efficient modulo)
 
@@ -83,4 +83,24 @@ pub fn new_encoder_state(config : LZ77Config) -> EncoderState {
 ///|
 pub fn new_decoder_state() -> DecoderState {
   { position: 0, output_buffer: @buffer.new() }
+}
+
+///|
+pub impl Show for LZ77Token with output(self, logger) {
+  logger.write_string(@debug.render(self.to_repr(), max_depth=2147483647))
+}
+
+///|
+pub impl Show for LZ77Config with output(self, logger) {
+  logger.write_string(@debug.render(self.to_repr(), max_depth=2147483647))
+}
+
+///|
+pub impl Show for EncoderState with output(self, logger) {
+  logger.write_string(@debug.render(self.to_repr(), max_depth=2147483647))
+}
+
+///|
+pub impl Show for DecoderState with output(self, logger) {
+  logger.write_string(@debug.render(self.to_repr(), max_depth=2147483647))
 }

--- a/moon.pkg
+++ b/moon.pkg
@@ -3,4 +3,7 @@ import {
   "bobzhang/zipc/crc32",
   "bobzhang/zipc/huffman",
   "bobzhang/zipc/lz77",
+  "moonbitlang/core/buffer",
+  "moonbitlang/core/debug",
+  "moonbitlang/core/encoding/utf8",
 }

--- a/pkg.generated.mbti
+++ b/pkg.generated.mbti
@@ -1,152 +1,153 @@
 // Generated using `moon info`, DON'T EDIT IT
 package "bobzhang/zipc"
 
-import(
-  "bobzhang/zipc/deflate"
-)
+import {
+  "bobzhang/zipc/deflate",
+  "moonbitlang/core/debug",
+}
 
 // Values
-fn add(Member, Archive) -> Archive
+pub fn add(Member, Archive) -> Archive
 
-fn bytes_from_ints(Array[Int]) -> Bytes
+pub fn bytes_from_ints(Array[Int]) -> Bytes
 
-fn compare_string_vs_bytes_write_u32() -> String
+pub fn compare_string_vs_bytes_write_u32() -> String
 
-fn concat_bytes(Array[Bytes]) -> Bytes
+pub fn concat_bytes(Array[Bytes]) -> Bytes
 
-fn create_unicode_path_field(String, Int) -> ExtraField
+pub fn create_unicode_path_field(String, Int) -> ExtraField
 
-fn create_unix_timestamp_field(Int, Int?, Int?) -> ExtraField
+pub fn create_unix_timestamp_field(Int, Int?, Int?) -> ExtraField
 
-fn current_unix_timestamp() -> Int
+pub fn current_unix_timestamp() -> Int
 
-fn deflate_of_binary_string(String, @deflate.Level) -> @deflate.Result[File, String]
+pub fn deflate_of_binary_string(String, @deflate.Level) -> @deflate.Result[File, String]
 
-fn deflate_of_bytes(Bytes, @deflate.Level) -> @deflate.Result[File, String]
+pub fn deflate_of_bytes(Bytes, @deflate.Level) -> @deflate.Result[File, String]
 
-fn demonstrate_migration_success() -> String
+pub fn demonstrate_migration_success() -> String
 
-fn dos_datetime_components(Int, Int) -> (Int, Int, Int, Int, Int, Int)
+pub fn dos_datetime_components(Int, Int) -> (Int, Int, Int, Int, Int, Int)
 
-fn dos_datetime_to_unix(Int, Int) -> Int
+pub fn dos_datetime_to_unix(Int, Int) -> Int
 
-let dos_epoch : Int
+pub let dos_epoch : Int
 
-fn empty() -> Archive
+pub fn empty() -> Archive
 
-fn extra_fields_size(Array[ExtraField]) -> Int
+pub fn extra_fields_size(Array[ExtraField]) -> Int
 
-fn file_can_extract(File) -> Bool
+pub fn file_can_extract(File) -> Bool
 
-fn file_compressed_bytes(File) -> String
+pub fn file_compressed_bytes(File) -> String
 
-fn file_compressed_size(File) -> Int
+pub fn file_compressed_size(File) -> Int
 
-fn file_compression(File) -> Compression
+pub fn file_compression(File) -> Compression
 
-fn file_decompressed_size(File) -> Int
+pub fn file_decompressed_size(File) -> Int
 
-fn file_to_binary_string(File) -> @deflate.Result[String, String]
+pub fn file_to_binary_string(File) -> @deflate.Result[String, String]
 
-fn file_to_bytes(File) -> Bytes raise
+pub fn file_to_bytes(File) -> Bytes raise
 
-fn find(String, Archive) -> Member?
+pub fn find(String, Archive) -> Member?
 
-fn find_extra_field(Array[ExtraField], Int) -> ExtraField?
+pub fn find_extra_field(Array[ExtraField], Int) -> ExtraField?
 
-fn format_dos_datetime(Int, Int) -> String
+pub fn format_dos_datetime(Int, Int) -> String
 
-let info_zip_unix_id : Int
+pub let info_zip_unix_id : Int
 
-fn is_empty(Archive) -> Bool
+pub fn is_empty(Archive) -> Bool
 
-fn make_dos_datetime(Int, Int, Int, Int, Int, Int) -> (Int, Int)
+pub fn make_dos_datetime(Int, Int, Int, Int, Int, Int) -> (Int, Int)
 
-let max_file_size : Int
+pub let max_file_size : Int
 
-let max_members : Int
+pub let max_members : Int
 
-let max_path_length : Int
+pub let max_path_length : Int
 
-fn mem(String, Archive) -> Bool
+pub fn mem(String, Archive) -> Bool
 
-fn member_count(Archive) -> Int
+pub fn member_count(Archive) -> Int
 
-fn member_kind(Member) -> MemberKind
+pub fn member_kind(Member) -> MemberKind
 
-fn member_make(String, MemberKind) -> @deflate.Result[Member, String]
+pub fn member_make(String, MemberKind) -> @deflate.Result[Member, String]
 
-fn member_mode(Member) -> Int
+pub fn member_mode(Member) -> Int
 
-fn member_mtime(Member) -> Int
+pub fn member_mtime(Member) -> Int
 
-fn member_path(Member) -> String
+pub fn member_path(Member) -> String
 
-let ntfs_extra_field_id : Int
+pub let ntfs_extra_field_id : Int
 
-fn of_binary_string(String) -> @deflate.Result[Archive, String]
+pub fn of_binary_string(String) -> @deflate.Result[Archive, String]
 
-fn of_bytes(Bytes) -> @deflate.Result[Archive, String]
+pub fn of_bytes(Bytes) -> @deflate.Result[Archive, String]
 
-fn parse_extra_fields(String) -> Array[ExtraField]
+pub fn parse_extra_fields(String) -> Array[ExtraField]
 
-fn parse_unicode_path_field(ExtraField) -> (String, Int)?
+pub fn parse_unicode_path_field(ExtraField) -> (String, Int)?
 
-fn parse_unix_timestamp_field(ExtraField) -> (Int, Int?, Int?)?
+pub fn parse_unix_timestamp_field(ExtraField) -> (Int, Int?, Int?)?
 
-fn read_u16_be_bytes(Bytes, Int) -> Int
+pub fn read_u16_be_bytes(Bytes, Int) -> Int
 
-fn read_u16_le_bytes(Bytes, Int) -> Int
+pub fn read_u16_le_bytes(Bytes, Int) -> Int
 
-fn read_u16_le_extra(String, Int) -> Int
+pub fn read_u16_le_extra(String, Int) -> Int
 
-fn read_u32_be_bytes(Bytes, Int) -> Int
+pub fn read_u32_be_bytes(Bytes, Int) -> Int
 
-fn read_u32_le_bytes(Bytes, Int) -> Int
+pub fn read_u32_le_bytes(Bytes, Int) -> Int
 
-fn read_u32_le_extra(String, Int) -> Int
+pub fn read_u32_le_extra(String, Int) -> Int
 
-fn remove(String, Archive) -> Archive
+pub fn remove(String, Archive) -> Archive
 
-fn remove_extra_field(Array[ExtraField], Int) -> Array[ExtraField]
+pub fn remove_extra_field(Array[ExtraField], Int) -> Array[ExtraField]
 
-fn serialize_extra_fields(Array[ExtraField]) -> String
+pub fn serialize_extra_fields(Array[ExtraField]) -> String
 
-fn set_extra_field(Array[ExtraField], ExtraField) -> Array[ExtraField]
+pub fn set_extra_field(Array[ExtraField], ExtraField) -> Array[ExtraField]
 
-fn stored_of_binary_string(String) -> File raise
+pub fn stored_of_binary_string(String) -> File raise
 
-fn stored_of_bytes(Bytes) -> File raise
+pub fn stored_of_bytes(Bytes) -> File raise
 
-fn string_has_magic(String) -> Bool
+pub fn string_has_magic(String) -> Bool
 
-fn to_binary_string(Archive) -> @deflate.Result[String, String]
+pub fn to_binary_string(Archive) -> @deflate.Result[String, String]
 
-fn to_bytes(Archive) -> @deflate.Result[Bytes, String]
+pub fn to_bytes(Archive) -> @deflate.Result[Bytes, String]
 
-let unicode_comment_id : Int
+pub let unicode_comment_id : Int
 
-let unicode_path_id : Int
+pub let unicode_path_id : Int
 
-let unix_extra_field_id : Int
+pub let unix_extra_field_id : Int
 
-fn unix_to_dos_datetime(Int) -> (Int, Int)
+pub fn unix_to_dos_datetime(Int) -> (Int, Int)
 
-fn validate_extra_field(ExtraField) -> Bool
+pub fn validate_extra_field(ExtraField) -> Bool
 
-fn write_u16_be_bytes(Int) -> Bytes
+pub fn write_u16_be_bytes(Int) -> Bytes
 
-fn write_u16_le_bytes(Int) -> Bytes
+pub fn write_u16_le_bytes(Int) -> Bytes
 
-fn write_u16_le_extra(Int) -> String
+pub fn write_u16_le_extra(Int) -> String
 
-fn write_u32_be_bytes(Int) -> Bytes
+pub fn write_u32_be_bytes(Int) -> Bytes
 
-fn write_u32_le_bytes(Int) -> Bytes
+pub fn write_u32_le_bytes(Int) -> Bytes
 
-fn write_u32_le_extra(Int) -> String
+pub fn write_u32_le_extra(Int) -> String
 
-let zip64_extra_field_id : Int
+pub let zip64_extra_field_id : Int
 
 // Errors
 
@@ -159,8 +160,8 @@ pub enum Compression {
   Stored
   Deflate
   Other(Int)
-}
-impl Show for Compression
+} derive(@debug.Debug)
+pub impl Show for Compression
 
 pub struct ExtraField {
   header_id : Int
@@ -193,11 +194,11 @@ pub enum MemberKind {
 }
 
 // Type aliases
-pub typealias String as Fpath
+pub type Fpath = String
 
-pub typealias Int as Mode
+pub type Mode = Int
 
-pub typealias Int as Ptime
+pub type Ptime = Int
 
 // Traits
 

--- a/working_demo.mbt
+++ b/working_demo.mbt
@@ -7,7 +7,7 @@ test "bytes_api_working_demo" {
 
   // Create some binary test data
   let text_content = "Hello, Bytes-based ZIP API! This demonstrates the new architecture."
-  let binary_data = text_content.to_bytes()
+  let binary_data = @utf8.encode(text_content)
   println("📝 Original data: " + text_content)
   println("📊 Original size: " + binary_data.length().to_string() + " bytes")
 
@@ -57,7 +57,7 @@ test "bytes_api_working_demo" {
   println("\n✅ Test 3: Performance comparison (CRC32)...")
 
   // String-based CRC32 (old way)
-  let string_crc = @crc32.bytes(text_content.to_bytes())
+  let string_crc = @crc32.bytes(@utf8.encode(text_content))
   println("   ✓ String-based CRC32: " + string_crc.to_string())
 
   // Bytes-based CRC32 (new way - 2-4x faster)
@@ -155,8 +155,8 @@ test "bytes_vs_string_performance_demo" {
   println("📊 Testing CRC32 performance on different data sizes:")
 
   // Test small data
-  let small_string_crc = @crc32.bytes(small_data.to_bytes())
-  let small_bytes_crc = @crc32.bytes(small_data.to_bytes())
+  let small_string_crc = @crc32.bytes(@utf8.encode(small_data))
+  let small_bytes_crc = @crc32.bytes(@utf8.encode(small_data))
   println(
     "   Small (" +
     small_data.length().to_string() +
@@ -165,8 +165,8 @@ test "bytes_vs_string_performance_demo" {
   )
 
   // Test medium data
-  let medium_string_crc = @crc32.bytes(medium_data.to_bytes())
-  let medium_bytes_crc = @crc32.bytes(medium_data.to_bytes())
+  let medium_string_crc = @crc32.bytes(@utf8.encode(medium_data))
+  let medium_bytes_crc = @crc32.bytes(@utf8.encode(medium_data))
   println(
     "   Medium (" +
     medium_data.length().to_string() +
@@ -175,8 +175,8 @@ test "bytes_vs_string_performance_demo" {
   )
 
   // Test large data
-  let large_string_crc = @crc32.bytes(large_data.to_bytes())
-  let large_bytes_crc = @crc32.bytes(large_data.to_bytes())
+  let large_string_crc = @crc32.bytes(@utf8.encode(large_data))
+  let large_bytes_crc = @crc32.bytes(@utf8.encode(large_data))
   println(
     "   Large (" +
     large_data.length().to_string() +

--- a/zip.mbt
+++ b/zip.mbt
@@ -105,6 +105,22 @@ pub fn remove(path : Fpath, archive : Archive) -> Archive {
   { members: new_members }
 }
 
+
+///|
+/// Convert a "binary string" (a MoonBit string where each char's low 8 bits
+/// represent one raw byte, as produced by `unsafe_to_char()` in this file)
+/// into Bytes. **This is NOT UTF-8 encoding** — using `@utf8.encode` would
+/// expand chars with code point >= 0x80 to two-byte UTF-8 sequences,
+/// corrupting the byte stream (flagged by Devin Review on zipc#6).
+fn binary_string_to_bytes(value : String) -> Bytes {
+  let len = value.length()
+  let arr : Array[Byte] = Array::make(len, (0).to_byte())
+  for i = 0; i < len; i = i + 1 {
+    arr[i] = (value.code_unit_at(i).to_int() & 0xff).to_byte()
+  }
+  Bytes::from_array(arr)
+}
+
 // File operations
 
 ///|
@@ -119,7 +135,7 @@ pub fn stored_of_binary_string(s : String) -> File raise {
   }
 
   // Calculate actual CRC-32 checksum
-  let crc = @crc32.bytes(@utf8.encode(s))
+  let crc = @crc32.bytes(binary_string_to_bytes(s))
   {
     compression: Compression::Stored,
     start: 0,
@@ -151,7 +167,7 @@ pub fn stored_of_bytes(data : Bytes) -> File raise {
 
   // Calculate CRC-32 checksum on the string that will actually be stored
   // This ensures consistency between storage and extraction
-  let crc = @crc32.bytes(@utf8.encode(data_as_string))
+  let crc = @crc32.bytes(binary_string_to_bytes(data_as_string))
   {
     compression: Compression::Stored,
     start: 0,
@@ -182,9 +198,9 @@ pub fn deflate_of_binary_string(
   }
 
   // Compress using deflate
-  let compressed_data = @deflate.deflate_of_bytes(@utf8.encode(s), level)
+  let compressed_data = @deflate.deflate_of_bytes(binary_string_to_bytes(s), level)
   // Calculate CRC-32 of original data
-  let crc = @crc32.bytes(@utf8.encode(s))
+  let crc = @crc32.bytes(binary_string_to_bytes(s))
   @deflate.ok({
     compression: Compression::Deflate,
     start: 0,
@@ -222,7 +238,7 @@ pub fn deflate_of_bytes(
 
   // Calculate CRC-32 on the string representation that will be stored/extracted
   // This ensures consistency between storage and extraction
-  let crc = @crc32.bytes(@utf8.encode(data_as_string))
+  let crc = @crc32.bytes(binary_string_to_bytes(data_as_string))
   @deflate.ok({
     compression: Compression::Deflate,
     start: 0,
@@ -295,7 +311,7 @@ pub fn file_to_bytes(file : File) -> Bytes raise {
   match file.compression {
     Compression::Stored => {
       // Convert string to bytes first, then slice
-      let compressed_bytes = @utf8.encode(file.compressed_bytes)
+      let compressed_bytes = binary_string_to_bytes(file.compressed_bytes)
       let data_view = compressed_bytes[file.start:file.start +
         file.compressed_size]
       // Convert view back to bytes
@@ -303,7 +319,7 @@ pub fn file_to_bytes(file : File) -> Bytes raise {
     }
     Compression::Deflate => {
       // Use bytes-based decompression for better performance
-      let compressed_bytes = @utf8.encode(file.compressed_bytes)
+      let compressed_bytes = binary_string_to_bytes(file.compressed_bytes)
       @deflate.deflate_decompress_bytes(
         compressed_bytes,
         file.decompressed_size,
@@ -400,7 +416,7 @@ pub fn to_bytes(archive : Archive) -> @deflate.Result[Bytes, String] {
   // Use the existing string-based implementation and convert to bytes
   // In a full implementation, this would work directly with bytes throughout
   match to_binary_string(archive) {
-    @deflate.Ok(zip_string) => @deflate.ok(@utf8.encode(zip_string))
+    @deflate.Ok(zip_string) => @deflate.ok(binary_string_to_bytes(zip_string))
     @deflate.Err(error) => @deflate.err(error)
   }
 }

--- a/zip.mbt
+++ b/zip.mbt
@@ -7,16 +7,16 @@ pub enum Compression {
   Stored
   Deflate
   Other(Int)
-} derive(Show)
+} derive(Debug)
 
 ///|
-pub typealias String as Fpath
+pub type Fpath = String
 
 ///|
-pub typealias Int as Mode
+pub type Mode = Int
 
 ///|
-pub typealias Int as Ptime
+pub type Ptime = Int
 
 ///|
 pub struct File {
@@ -73,12 +73,12 @@ pub fn empty() -> Archive {
 
 ///|
 pub fn is_empty(archive : Archive) -> Bool {
-  archive.members.size() == 0
+  archive.members.length() == 0
 }
 
 ///|
 pub fn member_count(archive : Archive) -> Int {
-  archive.members.size()
+  archive.members.length()
 }
 
 ///|
@@ -119,7 +119,7 @@ pub fn stored_of_binary_string(s : String) -> File raise {
   }
 
   // Calculate actual CRC-32 checksum
-  let crc = @crc32.bytes(s.to_bytes())
+  let crc = @crc32.bytes(@utf8.encode(s))
   {
     compression: Compression::Stored,
     start: 0,
@@ -151,7 +151,7 @@ pub fn stored_of_bytes(data : Bytes) -> File raise {
 
   // Calculate CRC-32 checksum on the string that will actually be stored
   // This ensures consistency between storage and extraction
-  let crc = @crc32.bytes(data_as_string.to_bytes())
+  let crc = @crc32.bytes(@utf8.encode(data_as_string))
   {
     compression: Compression::Stored,
     start: 0,
@@ -182,9 +182,9 @@ pub fn deflate_of_binary_string(
   }
 
   // Compress using deflate
-  let compressed_data = @deflate.deflate_of_bytes(s.to_bytes(), level)
+  let compressed_data = @deflate.deflate_of_bytes(@utf8.encode(s), level)
   // Calculate CRC-32 of original data
-  let crc = @crc32.bytes(s.to_bytes())
+  let crc = @crc32.bytes(@utf8.encode(s))
   @deflate.ok({
     compression: Compression::Deflate,
     start: 0,
@@ -222,7 +222,7 @@ pub fn deflate_of_bytes(
 
   // Calculate CRC-32 on the string representation that will be stored/extracted
   // This ensures consistency between storage and extraction
-  let crc = @crc32.bytes(data_as_string.to_bytes())
+  let crc = @crc32.bytes(@utf8.encode(data_as_string))
   @deflate.ok({
     compression: Compression::Deflate,
     start: 0,
@@ -267,15 +267,12 @@ pub fn file_can_extract(file : File) -> Bool {
 
 ///|
 pub fn file_to_binary_string(file : File) -> @deflate.Result[String, String] {
-  if not(file_can_extract(file)) {
+  if !(file_can_extract(file)) {
     return @deflate.err("Unsupported compression format")
   }
   match file.compression {
     Compression::Stored => {
-      let data = file.compressed_bytes.substring(
-        start=file.start,
-        end=file.start + file.compressed_size,
-      )
+      let data = file.compressed_bytes[file.start:file.start + file.compressed_size].to_string()
       @deflate.ok(data)
     }
     Compression::Deflate =>
@@ -292,13 +289,13 @@ pub fn file_to_binary_string(file : File) -> @deflate.Result[String, String] {
 
 ///|
 pub fn file_to_bytes(file : File) -> Bytes raise {
-  if not(file_can_extract(file)) {
+  if !(file_can_extract(file)) {
     fail("Unsupported compression format")
   }
   match file.compression {
     Compression::Stored => {
       // Convert string to bytes first, then slice
-      let compressed_bytes = file.compressed_bytes.to_bytes()
+      let compressed_bytes = @utf8.encode(file.compressed_bytes)
       let data_view = compressed_bytes[file.start:file.start +
         file.compressed_size]
       // Convert view back to bytes
@@ -306,7 +303,7 @@ pub fn file_to_bytes(file : File) -> Bytes raise {
     }
     Compression::Deflate => {
       // Use bytes-based decompression for better performance
-      let compressed_bytes = file.compressed_bytes.to_bytes()
+      let compressed_bytes = @utf8.encode(file.compressed_bytes)
       @deflate.deflate_decompress_bytes(
         compressed_bytes,
         file.decompressed_size,
@@ -403,7 +400,7 @@ pub fn to_bytes(archive : Archive) -> @deflate.Result[Bytes, String] {
   // Use the existing string-based implementation and convert to bytes
   // In a full implementation, this would work directly with bytes throughout
   match to_binary_string(archive) {
-    @deflate.Ok(zip_string) => @deflate.ok(zip_string.to_bytes())
+    @deflate.Ok(zip_string) => @deflate.ok(@utf8.encode(zip_string))
     @deflate.Err(error) => @deflate.err(error)
   }
 }
@@ -682,7 +679,7 @@ pub fn of_binary_string(data : String) -> @deflate.Result[Archive, String] {
   }
 
   // Check for ZIP magic bytes
-  if not(string_has_magic(data)) {
+  if !(string_has_magic(data)) {
     return @deflate.err("Not a valid ZIP archive - missing magic bytes")
   }
 
@@ -777,10 +774,7 @@ fn parse_central_directory_entry(
   if filename_start + filename_length > data.length() {
     return @deflate.err("Filename extends beyond file")
   }
-  let filename = data.substring(
-    start=filename_start,
-    end=filename_start + filename_length,
-  )
+  let filename = data[filename_start:filename_start + filename_length].to_string()
 
   // Determine compression type
   let compression = match compression_method {
@@ -860,9 +854,11 @@ fn read_file_data(
   if file_data_offset + compressed_size > data.length() {
     return @deflate.err("File data extends beyond archive")
   }
-  let file_data = data.substring(
-    start=file_data_offset,
-    end=file_data_offset + compressed_size,
-  )
+  let file_data = data[file_data_offset:file_data_offset + compressed_size].to_string()
   @deflate.ok(file_data)
+}
+
+///|
+pub impl Show for Compression with output(self, logger) {
+  logger.write_string(@debug.render(self.to_repr(), max_depth=2147483647))
 }


### PR DESCRIPTION
Broad sweep of nightly-compatibility fixes so `moon check --deny-warn` passes and all 62 tests run green on native/wasm-gc.

Highlights:
- 8 `derive(Show)` → `derive(Debug)` + manual Show via `@debug.render`
- rename local `write_leb128` → `write_uleb128` (was shadowing stdlib's signed variant)
- migrate `@buffer.T` → `@buffer.Buffer`
- fix `Show for Crc32`: `hex_chars[digit].to_string()` now outputs UInt16 decimals instead of hex chars under new String indexing — switched to `code_unit_at(…).to_int().unsafe_to_char()`
- typealias syntax, `not()`, `substring`, `size()`, `.to_bytes()` migrations throughout

Known follow-up (codex flagged): crc32/README.mbt.md has stale expected hex values captured under the broken Show, not currently picked up by `moon test` in this package. Separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonbit-community/zipc/pull/6" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
