### PR TITLE
Fix MoonBit warnings for 2026-05-09 promotion

### DIFF
--- a/deflate/deflate.mbt
+++ b/deflate/deflate.mbt
@@ -244,7 +244,7 @@ fn decompress_uncompressed_block_bytes(
   }
 
   // Extract the block data as bytes
-  let block_data = compressed[data_offset:data_offset + len].to_bytes()
+  let block_data = compressed[data_offset:data_offset + len].to_owned()
   (block_data, data_offset + len)
 }
 

--- a/deflate/gzip.mbt
+++ b/deflate/gzip.mbt
@@ -201,7 +201,7 @@ pub fn gzip_decompress_bytes(gzip_data : GzipData) -> Bytes raise {
     fail("Truncated gzip trailer")
   }
   let deflate_end = data.length() - 8
-  let deflate_bytes = data[offset:deflate_end].to_bytes()
+  let deflate_bytes = data[offset:deflate_end].to_owned()
 
   // Extract trailer: CRC-32 and original size
   let expected_crc = read_u32_le_bytes(data, deflate_end).to_int64()
@@ -347,7 +347,7 @@ pub fn gzip_extract_metadata_bytes(
       offset = offset + 1
     }
     if offset < compressed_data.length() {
-      filename = Some(compressed_data[start:offset].to_bytes().to_string())
+      filename = Some(compressed_data[start:offset].to_owned().to_string())
       offset = offset + 1
     }
   }
@@ -361,7 +361,7 @@ pub fn gzip_extract_metadata_bytes(
       offset = offset + 1
     }
     if offset < compressed_data.length() {
-      comment = Some(compressed_data[start:offset].to_bytes().to_string())
+      comment = Some(compressed_data[start:offset].to_owned().to_string())
       offset = offset + 1
     }
   }

--- a/deflate/zlib.mbt
+++ b/deflate/zlib.mbt
@@ -87,7 +87,7 @@ pub fn zlib_decompress_bytes(zlib_data : ZlibData) -> Bytes raise {
   // Extract deflate data (everything except header and trailing checksum)
   let deflate_start = 2
   let deflate_end = data.length() - 4
-  let deflate_bytes = data[deflate_start:deflate_end].to_bytes()
+  let deflate_bytes = data[deflate_start:deflate_end].to_owned()
 
   // Extract Adler-32 checksum (last 4 bytes, big-endian)
   let expected_adler = read_u32_be_bytes(data, deflate_end).to_int64()

--- a/extra_fields.mbt
+++ b/extra_fields.mbt
@@ -47,7 +47,7 @@ pub fn parse_extra_fields(data : String) -> Array[ExtraField] {
 
     // Read data
     if offset + data_size <= data.length() {
-      let field_data = data[offset:offset + data_size].to_string()
+      let field_data = data[offset:offset + data_size].to_owned()
       fields.push({ header_id, data_size, data: field_data })
       offset = offset + data_size
     } else {
@@ -193,7 +193,7 @@ pub fn parse_unicode_path_field(field : ExtraField) -> (String, Int)? {
     return None // Unsupported version
   }
   let crc32 = read_u32_le_extra(field.data, 1)
-  let unicode_path = field.data[5:field.data.length()].to_string()
+  let unicode_path = field.data[5:field.data.length()].to_owned()
   Some((unicode_path, crc32))
 }
 

--- a/zip.mbt
+++ b/zip.mbt
@@ -73,7 +73,7 @@ pub let max_path_length : Int = 65535
 
 ///|
 pub fn empty() -> Archive {
-  { members: Map::new() }
+  { members: Map([], capacity=0) }
 }
 
 ///|
@@ -297,7 +297,7 @@ pub fn file_to_binary_string(file : File) -> @deflate.Result[String, String] {
   match file.compression {
     Compression::Stored => {
       let data = file.compressed_bytes[file.start:file.start +
-      file.compressed_size].to_string()
+      file.compressed_size].to_owned()
       @deflate.ok(data)
     }
     Compression::Deflate =>
@@ -328,7 +328,7 @@ pub fn file_to_bytes(file : File) -> Bytes raise {
       let data_view = compressed_bytes[file.start:file.start +
         file.compressed_size]
       // Convert view back to bytes
-      data_view.to_bytes()
+      data_view.to_owned()
     }
     Compression::Deflate => {
       // Use bytes-based decompression for better performance
@@ -814,7 +814,7 @@ fn parse_central_directory_entry(
   if filename_start + filename_length > data.length() {
     return @deflate.err("Filename extends beyond file")
   }
-  let filename = data[filename_start:filename_start + filename_length].to_string()
+  let filename = data[filename_start:filename_start + filename_length].to_owned()
 
   // Determine compression type
   let compression = match compression_method {
@@ -894,6 +894,6 @@ fn read_file_data(
   if file_data_offset + compressed_size > data.length() {
     return @deflate.err("File data extends beyond archive")
   }
-  let file_data = data[file_data_offset:file_data_offset + compressed_size].to_string()
+  let file_data = data[file_data_offset:file_data_offset + compressed_size].to_owned()
   @deflate.ok(file_data)
 }


### PR DESCRIPTION
## Summary
- Fix MoonBit warnings reported by the community-cakes dashboard for the 2026-05-09 promotion run.
- Update deprecated APIs and debug assertions as needed.

## Validation
- `moon check --target all`
- `moon fmt`
- Tests were run where feasible during the promotion pass.

## Note
- Local tests passed, while existing demo output still prints archive/data integrity messages; this PR does not change that behavior.
