### PR TITLE
ci: add mooncakes publish workflow + bump to 0.1.2

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,48 @@
+name: publish-package
+run-name: publish to mooncakes
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    if: startsWith(github.ref, 'refs/tags/')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Install MoonBit
+        run: |
+          curl -fsSL https://cli.moonbitlang.com/install/unix.sh | bash
+          echo "$HOME/.moon/bin" >> "$GITHUB_PATH"
+
+      - name: MoonBit version
+        run: moon version --all
+
+      - name: Update registry index
+        run: moon update
+
+      - name: Verify tag matches module version
+        run: |
+          version="$(awk -F'"' '/^version[[:space:]]*=/{ print $2; exit }' moon.mod)"
+          tag="${GITHUB_REF_NAME#v}"
+          test "$tag" = "$version"
+
+      - name: Check
+        run: moon check --warn-list=-a
+
+      - name: Test
+        run: moon test --warn-list=-a
+
+      - name: Publish
+        run: |
+          echo "$SECRET" > ~/.moon/credentials.json
+          moon publish
+          rm ~/.moon/credentials.json
+        env:
+          SECRET: ${{ secrets.MOONCAKES_MOONBIT_COMMUNITY_TOKEN }}

--- a/moon.mod
+++ b/moon.mod
@@ -1,6 +1,6 @@
 name = "moonbit-community/zipc"
 
-version = "0.1.1"
+version = "0.1.2"
 
 readme = "README.md"
 


### PR DESCRIPTION
## What

- **Add `.github/workflows/publish.yml`** — the org-standard tag-triggered publisher (mirrors `unicodewidth.mbt` / `pty`): on a `v*` tag it verifies `tag == moon.mod version`, runs check/test, then `moon publish` using the org secret `MOONCAKES_MOONBIT_COMMUNITY_TOKEN`.
- **Bump `version` 0.1.1 → 0.1.2.**

## Why

The registry `0.1.1` was published **before** PR #10 (the RFC 1951 inflate fix) landed on `main`. Since mooncakes is version-keyed, `0.1.1` still serves the pre-fix code (the deflate decompressor was a placeholder that `fail`ed on dynamic-Huffman blocks). There was no publish workflow, so the fix never reached the registry.

This lets downstream consumers depend on `moonbit-community/zipc@0.1.2` from mooncakes (instead of a `git+` fork branch) and get the working inflate.

## After merge

Push tag `v0.1.2` to trigger the publish:
```
git tag v0.1.2 && git push origin v0.1.2
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)