### PR TITLE
fix(zip): preserve unix mode (exec bit) on decode

### DIFF
--- a/moon.mod
+++ b/moon.mod
@@ -1,6 +1,6 @@
 name = "moonbit-community/zipc"
 
-version = "0.1.2"
+version = "0.1.3"
 
 readme = "README.md"
 

--- a/zip.mbt
+++ b/zip.mbt
@@ -834,10 +834,25 @@ fn parse_central_directory_entry(
         (external_file_attrs & 0x10) != 0
       let kind = if is_directory { MemberKind::Dir } else { File(file) }
 
+      // Unix permission bits are stored in the HIGH 16 bits of the external file
+      // attributes, but only when the archive was created on a Unix host (the
+      // "version made by" high byte == 3). Honour them — most importantly the
+      // executable bit — instead of forcing every file to 0o644: that way an
+      // extracted tree round-trips byte-for-byte and hashes identically to what
+      // `unzip` / a NAR-based content hash produce. Non-Unix archives (high byte
+      // != 3, or a zero mode) fall back to the conventional defaults.
+      let unix_mode = if (version_made_by >> 8) == 3 {
+        (external_file_attrs >> 16) & 0o777
+      } else {
+        0
+      }
+
       // Create member
       let mem = {
         path: filename,
-        mode: if is_directory {
+        mode: if unix_mode != 0 {
+          unix_mode
+        } else if is_directory {
           0o755
         } else {
           0o644

--- a/zip_mode_wbtest.mbt
+++ b/zip_mode_wbtest.mbt
@@ -1,0 +1,28 @@
+// Regression: decoding a ZIP must preserve the unix permission bits stored in the
+// high 16 bits of a member's external file attributes (notably the executable
+// bit). The decoder used to hardcode 0o644 for every file, so an extracted tree
+// lost exec bits and no longer hashed like `unzip` / a NAR content hash.
+
+///|
+test "decode preserves the unix executable bit through a round-trip" {
+  let file = stored_of_binary_string("#!/bin/sh\necho hi\n")
+  let m0 = match member_make("run.sh", File(file)) {
+    Ok(m) => m
+    Err(e) => {
+      fail("member_make: \{e}")
+    }
+  }
+  // Force the executable mode, encode, decode.
+  let archive = add({ ..m0, mode: 0o755 }, empty())
+  let bytes = match to_binary_string(archive) {
+    Ok(b) => b
+    Err(e) => fail("encode: \{e}")
+  }
+  let decoded = match of_binary_string(bytes) {
+    Ok(a) => a
+    Err(e) => fail("decode: \{e}")
+  }
+  let got = decoded.members.get("run.sh").unwrap()
+  // The exec bit must survive (regression was: it came back 0o644).
+  inspect((member_mode(got) & 0o111) != 0, content="true")
+}


### PR DESCRIPTION
## Problem
The central-directory decoder hardcoded file `mode` to `0o644`, reading `external_file_attrs` only for the directory bit (`& 0x10`). The unix permission bits live in the **high 16 bits** of `external_file_attrs` (when the archive's host system is unix — "version made by" high byte `== 3`). So extraction dropped the **executable bit**, and an extracted tree no longer hashed identically to `unzip` or a NAR/`nix hash path` content hash.

## Fix
Read the stored unix mode when the host is unix; fall back to `0o644`/`0o755` otherwise. Adds a round-trip regression test (`run.sh` @ `0o755` → encode → decode → exec bit preserved). All 69 tests pass.

Bumps to **0.1.3**.

## After merge
Tag `v0.1.3` to trigger the publish workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)